### PR TITLE
Adjustment central content home page

### DIFF
--- a/src/components/CentralContentHome/styles.js
+++ b/src/components/CentralContentHome/styles.js
@@ -1,11 +1,14 @@
-import styled from "styled-components"
+import styled from "styled-components";
 
 export const CentralContent = styled.main`
+    position: absolute;
+    top: 15%;
     max-width: 100%;
-    height: auto;
+    width: 100%;
+    height: 70%;
     display: flex;
     justify-content: space-between;
-    padding: 0 8% 0 0;
+    padding-right: 3%;
     overflow: hidden;
     background: linear-gradient(105.96deg, #FFFFFF 0%, #F0F0F0 97.86%);
 `;

--- a/src/components/partials/Images/styles.js
+++ b/src/components/partials/Images/styles.js
@@ -1,19 +1,12 @@
 import styled from "styled-components";
 import BallLogoImg from '../../../assets/images/bola-LogoCompasso1.png'
 
-const Img = styled.img`
-    position: relative;
-    top: 7vh;
-    max-width: 100%;
-    height: 100%;
-    flex-shrink: 1;
-    display: block;
+const BallLogo = styled.div`
+    flex: 1;
+    background: url(${BallLogoImg});
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-position: left -20px bottom -15px;
 `;
-
-const BallLogo = () => {
-    return (
-        <Img src={BallLogoImg} />
-    )
-}
 
 export { BallLogo };

--- a/src/components/partials/Texts/styles.js
+++ b/src/components/partials/Texts/styles.js
@@ -2,36 +2,33 @@ import styled from "styled-components";
 
 const TextBlackMission = styled.span`
     color: #222222;
-    font-size: 24px;  
-    line-height: 30px;
+    font-size: clamp(12px,1.5vw,24px);
     text-align: right;
     font-family: MarkPro;
 `;
 
 const TextRedMediumMission = styled.span`
     color: #C12D18;
-    font-size: 36px;
-    line-height: 46px;
+    font-size: clamp(16px,2vw,36px);
     text-align: right;
     font-family: MarkProBold;
 `;
 
 const TextRedGreatMission = styled.span`
     color: #C12D18;
-    font-size: 64px;
-    line-height: 81px;
+    font-size: clamp(20px,3.5vw,64px);
     text-align: right;
-    padding-left: 50px;
     font-family: MarkProBold;
 `;
 
 const TextsMissionContainer = styled.div`
+    flex: 1.3;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     justify-content: center;
 
-    @media (max-width: 1024px) {
+    @media (max-width: 90vh) {
         display: none;
     }
 `;


### PR DESCRIPTION
Hi,

this branch brings fixes and improvements to the main content of the **Home Page**.

- Responsive main container, always occupying 70% of the screen and at a distance of 15% from the top or bottom.
- Responsive logo ball, taking up maximum screen width in mobile mode.
- Responsive mission texts, in order to be hidden in mobile mode and in order not to exceed other elements such as the logo and parent container.

For a better view in the review, comment out the header and footer call in HomePage.js. So, you will only have the main component isolated and showing:

```
function HomePage() {
  return (
    <div className="App">
          {/* <Header/> */}
          <CentralContentHome/>
          {/* <Footer/> */}
    </div>
  );
}
```

_Main in Desktop mode:_

![image](https://user-images.githubusercontent.com/47165472/156473777-4e484059-5e46-4170-9df9-bd1c0d2d6398.png)

==================================================================

_Main in Mobile mode (iPhone 4):_

![image](https://user-images.githubusercontent.com/47165472/156473973-14538a66-39a9-4c64-a162-ecd5884f35bf.png)

==================================================================

_Main in Tablet mode (iPad Air):_

![image](https://user-images.githubusercontent.com/47165472/156474407-f30fe5de-7562-4d84-8841-8dd68de27427.png)

==================================================================

**Remembering that the blank parts represent the header (Top) and footer (bottom) section.**

I am available for questions, suggestions and changes.

Thanks.